### PR TITLE
Convenient public method getConfig

### DIFF
--- a/src/BrowserDetector.php
+++ b/src/BrowserDetector.php
@@ -46,7 +46,6 @@ class BrowserDetector
      */
     private $config;
 
-
     /**
      * Constructor
      *

--- a/src/BrowserDetector.php
+++ b/src/BrowserDetector.php
@@ -40,6 +40,14 @@ class BrowserDetector
     private $compatibility;
 
     /**
+     * Config
+     *
+     * @var array
+     */
+    private $config;
+
+
+    /**
      * Constructor
      *
      * @param boolean $browscapEnabled Is browscap enabled
@@ -61,6 +69,7 @@ class BrowserDetector
      */
     public function loadConfiguration($config)
     {
+        $this->config = $config;
         foreach ($config as $support => $requirement) {
             foreach ($requirement as $name => $version) {
                 $this->requirements[$support][ucwords($name)] = $this->parseVersion($version);
@@ -198,5 +207,15 @@ class BrowserDetector
     public function isIncompatible()
     {
         return $this->compatibility === self::BROWSER_INCOMPATIBLE;
+    }
+
+    /**
+     * Get the config
+     *
+     * @return array
+     */
+    public function getConfig()
+    {
+       return $this->config;
     }
 }


### PR DESCRIPTION
We can easily get all rules defined in our config.

Exemple in my symfony 2 project:

foreach ($this->browserDetector->getConfig() as $requirementType => $requirement) {
//e.g. display each rule
}
